### PR TITLE
重构 BaseAbility

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [8.x, 9.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm i -g npminstall && npminstall
+    - run: npm run ci
+      env:
+        CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 9.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-sudo: false
+
 language: node_js
 node_js:
   - '8'
   - '9'
+before_install:
+  - npm i npminstall -g
 install:
-  - npm i npminstall && npminstall
+  - npminstall
 script:
   - npm run ci
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 
 language: node_js
 node_js:
-  - '8'
-  - '9'
+  - '10'
+  - '12'
+  - '14'
 before_install:
   - npm i npminstall -g
 install:

--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ When you wrote `app/ability.js`, you may need to write test case.
 
 - egg-sequelize
 - factory-girl-sequelize
-- power-assert
 
 Create a test file: `test/ability.test.js`
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ exports.cancan = {
   contextUserMethod: 'user',
   // Enable disable Ability check result cache
   cache: false,
+  // Enable log authorize check result
+  log: false,
 };
 ```
 

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -16,6 +16,7 @@ module.exports = {
    * @param {Object} options.type name of ability, etc: topic|doc, if **obj** is a Sequelize instance, will use obj.Model.name by default
    * @return {Boolean} true | false
    */
+
   async can(...args) {
     return await this.ability.can(...args);
   },
@@ -27,6 +28,7 @@ module.exports = {
    * @param {Object} options options
    * @param {Object} options.type name of ability, etc: topic|doc, if **obj** is a Sequelize instance, will use obj.Model.name by default
    */
+
   async authorize(...args) {
     await this.ability.authorize(...args);
   },
@@ -38,6 +40,7 @@ module.exports = {
    * @param {String} options.type name of ability, etc: topic|doc
    * @return {Object} { read: true, update: true, delete: false }
    */
+
   async abilities(...args) {
     return await this.ability.abilities(...args);
   },
@@ -45,6 +48,7 @@ module.exports = {
   /**
    * Ability for currentUser
    */
+
   get ability() {
     if (this[ABILITY]) { return this[ABILITY]; }
 

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -2,10 +2,6 @@
 
 const ABILITY = Symbol('Context#ability');
 
-class CanCanAccessDenied extends Error {
-  get name() { return 'CanCanAccessDenied'; }
-}
-
 /**
  * Context::Ability
  *
@@ -20,8 +16,8 @@ module.exports = {
    * @param {Object} options.type name of ability, etc: topic|doc, if **obj** is a Sequelize instance, will use obj.Model.name by default
    * @return {Boolean} true | false
    */
-  async can(action, obj, options = {}) {
-    return await this.ability.can(action, obj, options);
+  async can(...args) {
+    return await this.ability.can(...args);
   },
 
   /**
@@ -31,9 +27,8 @@ module.exports = {
    * @param {Object} options options
    * @param {Object} options.type name of ability, etc: topic|doc, if **obj** is a Sequelize instance, will use obj.Model.name by default
    */
-  async authorize(action, obj, options = {}) {
-    const allow = await this.can(action, obj, options);
-    if (!allow) throw new CanCanAccessDenied('Access denied');
+  async authorize(...args) {
+    await this.ability.authorize(...args);
   },
 
   /**
@@ -43,16 +38,8 @@ module.exports = {
    * @param {String} options.type name of ability, etc: topic|doc
    * @return {Object} { read: true, update: true, delete: false }
    */
-  async abilities(obj, options = {}) {
-    const [ read, update, _delete ] = await Promise.all([
-      this.can('read', obj, options),
-      this.can('update', obj, options),
-      this.can('delete', obj, options),
-    ]);
-
-    const abilities = { read, update, delete: _delete };
-
-    return abilities;
+  async abilities(...args) {
+    return await this.ability.abilities(...args);
   },
 
   /**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
-    - nodejs_version: '8'
-    - nodejs_version: '9'
+    - nodejs_version: '10'
+    - nodejs_version: '12'
+    - nodejs_version: '14'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -9,4 +9,6 @@ exports.cancan = {
   contextUserMethod: 'user',
   // Enable disable Ability check result cache
   cache: false,
+  // Enable log for every check
+  log: false,
 };

--- a/lib/base_ability.js
+++ b/lib/base_ability.js
@@ -1,14 +1,19 @@
 'use strict';
 
+const assert = require('assert');
+
 class BaseAbility {
   constructor(ctx, user) {
     this.ctx = ctx;
     this.user = user || null;
     this._cache = {};
-    this._cacheEnable = ctx.app.config.cancan.cache || false;
+    this._cacheEnable = ctx.app.config.cancan.cache;
+    this._logEnable = ctx.app.config.cancan.log;
   }
 
   async can(action, obj, options = {}) {
+    assert(action && obj, 'action and object required, for example: ctx.can(\'read\', doc)');
+
     let { type } = options;
 
     // For egg-sequelize Model instance
@@ -18,9 +23,7 @@ class BaseAbility {
       }
     }
 
-    if (!type) {
-      throw new Error('Fail get type from obj argument, please present its by options, for example: ctx.can(\'read\', topic, { type: \'topic\' })');
-    }
+    assert(type, 'Fail get type from obj argument, please present its by options, for example: ctx.can(\'read\', topic, { type: \'topic\' })');
 
     switch (action) {
       case 'show':
@@ -41,22 +44,32 @@ class BaseAbility {
     options.type = type;
 
     if (!this._cacheEnable) {
-      return await this.rules(action, obj, options);
+      const allow = await this.rules(action, obj, options);
+      console.log('~~~~~', allow, this.rules.toString());
+      this.log(action, type, allow);
+      return allow;
     }
 
     const cacheKey = this.cacheKey(action, obj, options);
     if (cacheKey in this._cache) {
-      return this._cache[cacheKey];
+      const allow = this._cache[cacheKey];
+      this.log(action, type, allow, true);
+      return allow;
     }
 
     const allow = await this.rules(action, obj, options);
     this._cache[cacheKey] = allow;
+    this.log(action, type, allow);
     return allow;
   }
 
-  async rules(action, obj, options = {}) {
-    const { type } = options;
+  async log(action, type, allow, hit) {
+    // can be overridden to log more infomations
+    if (this._logEnable) this.ctx.logger.info('[cancan]can %s %s result %s, %s cache', action, type, allow, hit ? 'hit' : 'miss');
+  }
 
+  async rules(/* action, obj, options = {} */) {
+    // must be overridden
     return true;
   }
 

--- a/lib/base_ability.js
+++ b/lib/base_ability.js
@@ -2,6 +2,9 @@
 
 const assert = require('assert');
 
+class CanCanAccessDenied extends Error {
+  get name() { return 'CanCanAccessDenied'; }
+}
 class BaseAbility {
   constructor(ctx, user) {
     this.ctx = ctx;
@@ -9,6 +12,25 @@ class BaseAbility {
     this._cache = {};
     this._cacheEnable = ctx.app.config.cancan.cache;
     this._logEnable = ctx.app.config.cancan.log;
+  }
+
+  get CanCanAccessDenied() {
+    return CanCanAccessDenied;
+  }
+
+  async authorize(action, obj, options) {
+    const allow = await this.can(action, obj, options);
+    if (!allow) throw new CanCanAccessDenied('Access denied');
+  }
+
+  async abilities(obj, options) {
+    const [ read, update, _delete ] = await Promise.all([
+      this.can('read', obj, options),
+      this.can('update', obj, options),
+      this.can('delete', obj, options),
+    ]);
+
+    return { read, update, delete: _delete };
   }
 
   async can(action, obj, options = {}) {
@@ -45,7 +67,6 @@ class BaseAbility {
 
     if (!this._cacheEnable) {
       const allow = await this.rules(action, obj, options);
-      console.log('~~~~~', allow, this.rules.toString());
       this.log(action, type, allow);
       return allow;
     }

--- a/lib/base_ability.js
+++ b/lib/base_ability.js
@@ -34,7 +34,7 @@ class BaseAbility {
   }
 
   async can(action, obj, options = {}) {
-    assert(action && obj, 'action and object required, for example: ctx.can(\'read\', doc)');
+    assert(action, 'action required, for example: ctx.can(\'read\', doc)');
 
     let { type } = options;
 

--- a/lib/base_ability.js
+++ b/lib/base_ability.js
@@ -70,26 +70,26 @@ class BaseAbility {
 
     if (!this._cacheEnable) {
       const allow = await this.rules(action, obj, options);
-      this.log(action, type, allow);
+      this.log(action, type, allow, 'unuse');
       return allow;
     }
 
     const cacheKey = this.cacheKey(action, obj, options);
     if (cacheKey in this._cache) {
       const allow = this._cache[cacheKey];
-      this.log(action, type, allow, true);
+      this.log(action, type, allow, 'hit');
       return allow;
     }
 
     const allow = await this.rules(action, obj, options);
     this._cache[cacheKey] = allow;
-    this.log(action, type, allow);
+    this.log(action, type, allow, 'miss');
     return allow;
   }
 
-  async log(action, type, allow, hit) {
+  async log(action, type, allow, cache) {
     // can be overridden to log more infomations
-    if (this._logEnable) this.ctx.logger.info('[cancan]can %s %s result %s, %s cache', action, type, allow, hit ? 'hit' : 'miss');
+    if (this._logEnable) this.ctx.logger.info('[cancan]can %s %s result %s, %s cache', action, type, allow, cache);
   }
 
   async rules(/* action, obj, options = {} */) {

--- a/lib/base_ability.js
+++ b/lib/base_ability.js
@@ -34,10 +34,13 @@ class BaseAbility {
   }
 
   async can(action, obj, options = {}) {
+    // action must provide
     assert(action, 'action required, for example: ctx.can(\'read\', doc)');
 
-    let { type } = options;
+    // can('read', null) always return false
+    if (!obj) return false;
 
+    let { type } = options;
     // For egg-sequelize Model instance
     if (!type) {
       if (obj && obj.Model) {

--- a/package.json
+++ b/package.json
@@ -13,15 +13,14 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "autod": "^3.0.0",
-    "autod-egg": "^1.0.0",
-    "egg": "^2.0.0",
-    "egg-bin": "^4.3.0",
-    "egg-ci": "^1.8.0",
-    "egg-mock": "^3.13.0",
-    "power-assert": "^1.5.0",
-    "eslint": "^4.11.0",
-    "eslint-config-egg": "^5.1.0",
+    "autod": "^3.1.0",
+    "autod-egg": "^1.1.0",
+    "egg": "^2.27.0",
+    "egg-bin": "^4.15.0",
+    "egg-ci": "^1.15.0",
+    "egg-mock": "^4.0.0",
+    "eslint": "^7.4.0",
+    "eslint-config-egg": "^8.0.1",
     "webstorm-disable-index": "^1.2.0"
   },
   "engines": {
@@ -44,7 +43,7 @@
     "app.js"
   ],
   "ci": {
-    "version": "8, 9"
+    "version": "10, 12, 14"
   },
   "repository": {
     "type": "git",

--- a/test/.setup.js
+++ b/test/.setup.js
@@ -1,7 +1,6 @@
 'use strict';
 
 global.mm = require('egg-mock');
-global.assert = require('power-assert');
 
 const app = mm.app({ baseDir: 'apps/dummy', plugin: 'dummy' });
 

--- a/test/base_ability.test.js
+++ b/test/base_ability.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const { BaseAbility } = require('../');
 
 describe('test/base_ability.test.js', () => {

--- a/test/base_ability.test.js
+++ b/test/base_ability.test.js
@@ -31,6 +31,39 @@ describe('test/base_ability.test.js', () => {
       assert.deepEqual({}, ability._cache);
       assert.equal(null, anonymousAbility.user);
       assert.equal(ctx, anonymousAbility.ctx);
+      assert(ability.CanCanAccessDenied.name === 'CanCanAccessDenied');
+      assert(ability.CanCanAccessDenied === anonymousAbility.CanCanAccessDenied);
+    });
+  });
+
+  describe('authorize', () => {
+    it('should work', async () => {
+      mm(ability, 'rules', async action => {
+        if (action === 'read') return true;
+        return false;
+      });
+
+      await ability.authorize('read', modelInstance);
+      await assert.rejects(async () => {
+        await ability.authorize('update', modelInstance);
+      }, err => {
+        assert(err.name === 'CanCanAccessDenied');
+        return true;
+      });
+    });
+  });
+
+  describe('abilities', () => {
+    it('should work', async () => {
+      mm(ability, 'rules', async action => {
+        if (action === 'read') return true;
+        return false;
+      });
+
+      const res = await ability.abilities(modelInstance);
+      assert(res.read === true);
+      assert(res.update === false);
+      assert(res.delete === false);
     });
   });
 
@@ -95,6 +128,9 @@ describe('test/base_ability.test.js', () => {
 
       res = await ability.can('destroy', modelInstance);
       assert.equal('delete', res.action);
+
+      res = await ability.can('new', modelInstance);
+      assert.equal('create', res.action);
     });
   });
 

--- a/test/base_ability.test.js
+++ b/test/base_ability.test.js
@@ -106,4 +106,20 @@ describe('test/base_ability.test.js', () => {
       assert.equal('aaa', res.type);
     });
   });
+
+  describe('log', () => {
+    beforeEach(() => {
+      mm(app.config.cancan, 'log', true);
+      mm(app.config.cancan, 'cache', true);
+      ability = new BaseAbility(ctx, user);
+    });
+
+    it('should work', async () => {
+      app.mockLog();
+      res = await ability.can('read', modelInstance);
+      app.expectLog('[cancan]can read user result true, miss cache');
+      res = await ability.can('read', modelInstance);
+      app.expectLog('[cancan]can read user result true, hit cache');
+    });
+  });
 });

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assert = require('assert');
+
 describe('test/context.test.js', () => {
   // egg-sequelize model instance
   const modelInstance = {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -95,17 +95,11 @@ describe('test/context.test.js', () => {
     let abilities;
     it('should work', async () => {
       assert.ok(ctx.abilities);
-      mm(ctx, 'can', async (action, obj, options) => {
-        if (obj === null) return false;
+      mm(ctx.ability, 'can', async (action, obj, options) => {
         if (action === 'read') return true;
-        if (options.type === 'comment') return true;
+        if (options && options.type === 'comment') return true;
         return false;
       });
-
-      abilities= await ctx.abilities(null);
-      assert.equal(false, abilities.read);
-      assert.equal(false, abilities.update);
-      assert.equal(false, abilities.delete);
 
       abilities = await ctx.abilities({});
       assert.equal(true, abilities.read);

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -44,18 +44,11 @@ describe('test/context.test.js', () => {
       });
     });
 
-    it('should throw error when action or target not exist', async () => {
-      await assert.rejects(async () => {
-        await ctx.can('read');
-      }, err => {
-        assert.equal(`action and object required, for example: ctx.can('read', doc)`, err.message);
-        return true;
-      });
-
+    it('should throw error when action not exist', async () => {
       await assert.rejects(async () => {
         await ctx.can();
       }, err => {
-        assert.equal(`action and object required, for example: ctx.can('read', doc)`, err.message);
+        assert.equal(`action required, for example: ctx.can('read', doc)`, err.message);
         return true;
       });
     });
@@ -96,10 +89,16 @@ describe('test/context.test.js', () => {
     it('should work', async () => {
       assert.ok(ctx.abilities);
       mm(ctx.ability, 'can', async (action, obj, options) => {
+        if (obj === null) return false;
         if (action === 'read') return true;
         if (options && options.type === 'comment') return true;
         return false;
       });
+
+      abilities = await ctx.abilities(null);
+      assert.equal(false, abilities.read);
+      assert.equal(false, abilities.update);
+      assert.equal(false, abilities.delete);
 
       abilities = await ctx.abilities({});
       assert.equal(true, abilities.read);

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -18,7 +18,6 @@ describe('test/context.test.js', () => {
   describe('.can', () => {
     it('should work', async () => {
       assert.ok(ctx.can);
-      assert.equal(true, await ctx.can('read', null, { type: 'foo' }));
       assert.equal(true, await ctx.can('read', {}, { type: 'User' }));
     });
 
@@ -37,11 +36,28 @@ describe('test/context.test.js', () => {
     });
 
     it('should throw error when type not exist', async () => {
-      try {
+      await assert.rejects(async () => {
         await ctx.can('read', { id: 1 });
-      } catch (e) {
-        assert.equal(`Fail get type from obj argument, please present its by options, for example: ctx.can('read', topic, { type: 'topic' })`, e.message);
-      }
+      }, err => {
+        assert.equal(`Fail get type from obj argument, please present its by options, for example: ctx.can('read', topic, { type: 'topic' })`, err.message);
+        return true;
+      });
+    });
+
+    it('should throw error when action or target not exist', async () => {
+      await assert.rejects(async () => {
+        await ctx.can('read');
+      }, err => {
+        assert.equal(`action and object required, for example: ctx.can('read', doc)`, err.message);
+        return true;
+      });
+
+      await assert.rejects(async () => {
+        await ctx.can();
+      }, err => {
+        assert.equal(`action and object required, for example: ctx.can('read', doc)`, err.message);
+        return true;
+      });
     });
   });
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -19,6 +19,8 @@ describe('test/context.test.js', () => {
     it('should work', async () => {
       assert.ok(ctx.can);
       assert.equal(true, await ctx.can('read', {}, { type: 'User' }));
+      assert.equal(false, await ctx.can('read', null));
+      assert.equal(false, await ctx.can('read'));
     });
 
     it('should alias action work', async () => {


### PR DESCRIPTION
- 将 abilities / authorize 等方法从 context 中放到 BaseAbility 中，以便 `new app.Ability()` 使用这些方法
- action 不传递直接抛异常
- obj 不传递返回 null
- 增加 config.log 打印日志，同时增加 Ability.log 方法，可以被覆盖